### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Use Ubuntu 20.04 as base image
+FROM ubuntu:20.04
+
+# Copy source files to directory
+COPY . .
+
+# Install dependency
+RUN apt update && \
+    DEBIAN_FRONTEND=noninteractive apt install libsdl2-dev cmake g++ make -y
+
+# Build recipe
+RUN cd RVO2 && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    make install && \
+    cd ../../rds && \
+    make

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The software's structure is as in the following picture.
 
 Instructions follow to set up and run RDS and some demos in Ubuntu 16.04. Below, the first section is for simulations, and the second section is for the ROS interface. First, the following steps are necessary in both cases.
 
+You can use docker to build and execute RDS following [this guide](docs/docker.md).
+
 This installs the graphics library SDL2, which is a prerequisite.
 
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,33 @@
+# Using Docker to run RDS
+
+Follow this guide to run RDS on docker.
+
+## Requirements
+
+The only dependency that you should install is the standard Docker Engine:
+
+- Install Docker Engine: https://docs.docker.com/engine/install/
+
+## Build local docker image
+```
+docker build -t rds:latest .
+```
+
+## Run
+
+Once the docker image is built, you can run the software using the following:
+
+```
+docker run -i -w <DIRECTORY> rds:latest <COMMAND>
+```
+
+where:
+- `<DIRECTORY>` is the base directory to execute the command
+- `<COMMAND>` is the executable string
+
+For example, to run the simulation, located on `/rds`:
+
+```
+docker run -i -w /rds rds:latest ./build/baseline_crowd_rds_5 7
+```
+


### PR DESCRIPTION
This PR adds a docker image to make reproducibility easier regardless of the local environment setup:
- dependencies do not need to be installed in the user OS
- dependencies are clearly stated from an empty OS image
- OS, tool versions and installing scripts can be versioned
- less commands to be taken care from the user: just build and execute!

With this PR, as documented in `docs/docker.md`, user can simply run:
```
docker build -t rds:latest .
docker run -i -w /rds rds:latest ./build/baseline_crowd_rds_5 7
```

#### Tests
This PR has not been fully tested apart from the commands listed above, and no correctness check has been made with the output.

#### Next steps
Given the time allocated to this PR, I've just added to the docker image the main dependency (`libsdl2-dev`). Next steps would comprise adding [ROS Kinetic](http://wiki.ros.org/kinetic/Installation/Ubuntu) and the [catkin command line tools](https://catkin-tools.readthedocs.io/en/latest/installing.html) install scripts to the `Dockerfile` file.